### PR TITLE
some new features because south america

### DIFF
--- a/multitemporal/bin/shifttime.pyx
+++ b/multitemporal/bin/shifttime.pyx
@@ -1,0 +1,45 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+
+def get_nout(int nin, np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+    return nin
+
+def get_nyrout(int nyr, np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+    return nyr
+
+def shifttime(np.ndarray[np.float32_t, ndim=3, negative_indices=False] data not None,
+                float missingval,
+                np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+
+    cdef unsigned int nfr = data.shape[0]
+    cdef unsigned int nyr = data.shape[1]
+    cdef unsigned int npx = data.shape[2]
+
+    cdef int offset = <int>params[0] - 1
+
+    cdef np.ndarray[np.float32_t, ndim=3] result = np.zeros((nfr, nyr, npx), dtype='float32')
+
+    cdef int i, j, k
+    cdef int t, nt
+    cdef int t1, i1, j1
+    cdef float count, ave
+
+    nt = nfr*nyr
+
+    for k in range(npx):
+        for t in range(nt):
+            t1 = t - offset
+            if t1 < 0:
+                continue
+            i = t % nfr
+            j = t / nfr
+            i1 = t1 % nfr
+            j1 = t1 / nfr
+            result[i1,j1,k] = data[i,j,k]
+
+    return result

--- a/multitemporal/bin/trimyr.pyx
+++ b/multitemporal/bin/trimyr.pyx
@@ -1,0 +1,41 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+
+def get_nout(int nin, np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+    return nin
+
+def get_nyrout(int nyr, np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+    return params[0] - params[1] + 1
+
+def trimyr(np.ndarray[np.float32_t, ndim=3, negative_indices=False] data not None,
+           float missingval,
+           np.ndarray[np.float32_t, ndim=1, negative_indices=False] params not None):
+
+    cdef unsigned int nfr = data.shape[0]
+    cdef unsigned int nyr = data.shape[1]
+    cdef unsigned int npx = data.shape[2]
+
+    cdef int nout = get_nout(nfr, params)
+    cdef int nyrout = get_nyrout(nyr, params)
+
+    cdef int yr1 = <int>params[0] - 1
+    cdef int yr2 = <int>params[1] - 1
+
+    cdef np.ndarray[np.float32_t, ndim=3] result = np.zeros((nout,nyrout,npx), dtype='float32')
+
+    cdef unsigned int i,j,k,idx
+
+    for k in range(npx):
+        jdx = 0
+        for j in range(nyr):
+            if j>= yr1 and j <= yr2:
+                for i in range(nfr):
+                    result[i,jdx,k] = data[i,j,k]
+                jdx = jdx + 1
+
+    return result


### PR DESCRIPTION
- shifttime.pyx module in case the season starts at a weird time

- trimyr.pyx module because shifttime can result in a trailing useless year (also could consider an option to shifttime, but this seemed potentially useful

- Modules can now change the number of years they output (nyrout), e.g. trimyr.pyx

- Regex can now contain a group besides the date, but if so, they need to be labeled (backwards compatible), in our use case that group is used to handle data from different locations mixed in the same directory
